### PR TITLE
#128 - added one new method for sending domain management to delete r…

### DIFF
--- a/examples/Mailtrap.Example.SendingDomain/SendingDomain.cs
+++ b/examples/Mailtrap.Example.SendingDomain/SendingDomain.cs
@@ -61,8 +61,8 @@ try
 
     // Delete sending domain
     // Beware that sending domain resource becomes invalid after deletion and should not be used anymore
-    var result = await domainResource.Delete();
-    logger.LogInformation("Sending domain deleted: {Result}", result);
+    await domainResource.Delete();
+    logger.LogInformation("Sending domain deleted.");
 }
 catch (Exception ex)
 {

--- a/examples/Mailtrap.Example.SendingDomain/SendingDomain.cs
+++ b/examples/Mailtrap.Example.SendingDomain/SendingDomain.cs
@@ -58,6 +58,11 @@ try
     // Sending domain instructions
     var instructionsRequest = new SendingDomainInstructionsRequest("admin@demomailtrap.com");
     await domainResource.SendInstructions(instructionsRequest);
+
+    // Delete sending domain
+    // Beware that sending domain resource becomes invalid after deletion and should not be used anymore
+    var result = await domainResource.Delete();
+    logger.LogInformation("Sending domain deleted: {Result}", result);
 }
 catch (Exception ex)
 {

--- a/src/Mailtrap.Abstractions/Projects/IProjectResource.cs
+++ b/src/Mailtrap.Abstractions/Projects/IProjectResource.cs
@@ -41,15 +41,12 @@ public interface IProjectResource : IRestResource
     /// <summary>
     /// Deletes a project, represented by the current resource instance, with all its inboxes.
     /// </summary>
-    ///
     /// <param name="cancellationToken">
     /// <inheritdoc cref="GetDetails(CancellationToken)" path="/param[@name='cancellationToken']"/>
     /// </param>
-    /// 
     /// <returns>
     /// Deleted project details.
     /// </returns>
-    ///
     /// <remarks>
     /// <para>
     /// All inboxes, associated with the project, will be deleted as well.

--- a/src/Mailtrap.Abstractions/SendingDomains/ISendingDomainResource.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/ISendingDomainResource.cs
@@ -9,11 +9,11 @@ public interface ISendingDomainResource : IRestResource
     /// <summary>
     /// Gets domain data and status of sending domain, represented by this resource instance.
     /// </summary>
-    /// 
+    ///
     /// <param name="cancellationToken">
     /// Token to control operation cancellation.
     /// </param>
-    /// 
+    ///
     /// <returns>
     /// Attributes, DNS records, status, etc. for domain.
     /// </returns>
@@ -23,7 +23,7 @@ public interface ISendingDomainResource : IRestResource
     /// Sends setup instructions for sending domain, represented by this resource instance,
     /// to the recipient specified by <paramref name="request"/>.
     /// </summary>
-    /// 
+    ///
     /// <param name="request">
     /// Request containing recipient details to send setup instructions to.
     /// </param>
@@ -31,9 +31,29 @@ public interface ISendingDomainResource : IRestResource
     /// <param name="cancellationToken">
     /// <inheritdoc cref="GetDetails(CancellationToken)" path="/param[@name='cancellationToken']"/>
     /// </param>
-    /// 
+    ///
     /// <returns>
     /// <see cref="Task"/> instance, representing the operation completion.
     /// </returns>
     public Task SendInstructions(SendingDomainInstructionsRequest request, CancellationToken cancellationToken = default);
+
+
+    /// <summary>
+    /// Deletes a sendingdomain, represented by the current resource instance.
+    /// </summary>
+    ///
+    /// <param name="cancellationToken">
+    /// <inheritdoc cref="GetDetails(CancellationToken)" path="/param[@name='cancellationToken']"/>
+    /// </param>
+    ///
+    /// <returns>
+    /// Ok response, indicating that the sending domain has been deleted successfully.
+    /// </returns>
+    ///
+    /// <remarks>
+    /// <para>
+    /// After deletion of the sendingdomain, represented by the current resource instance, it will be no longer available.<br />
+    /// </para>
+    /// </remarks>
+    public Task Delete(CancellationToken cancellationToken = default);
 }

--- a/src/Mailtrap.Abstractions/SendingDomains/ISendingDomainResource.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/ISendingDomainResource.cs
@@ -39,7 +39,7 @@ public interface ISendingDomainResource : IRestResource
 
 
     /// <summary>
-    /// Deletes a sendingdomain, represented by the current resource instance.
+    /// Deletes a sending domain, represented by the current resource instance.
     /// </summary>
     ///
     /// <param name="cancellationToken">
@@ -47,12 +47,12 @@ public interface ISendingDomainResource : IRestResource
     /// </param>
     ///
     /// <returns>
-    /// Ok response, indicating that the sending domain has been deleted successfully.
+    /// A task that represents the completion of the delete operation.
     /// </returns>
     ///
     /// <remarks>
     /// <para>
-    /// After deletion of the sendingdomain, represented by the current resource instance, it will be no longer available.<br />
+    /// On success the API returns HTTP 204 (No Content). After deletion, the sending domain represented by this resource instance will no longer be available.
     /// </para>
     /// </remarks>
     public Task Delete(CancellationToken cancellationToken = default);

--- a/src/Mailtrap.Abstractions/SendingDomains/ISendingDomainResource.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/ISendingDomainResource.cs
@@ -41,19 +41,14 @@ public interface ISendingDomainResource : IRestResource
     /// <summary>
     /// Deletes a sending domain, represented by the current resource instance.
     /// </summary>
-    ///
-    /// <param name="cancellationToken">
-    /// <inheritdoc cref="GetDetails(CancellationToken)" path="/param[@name='cancellationToken']"/>
-    /// </param>
-    ///
-    /// <returns>
-    /// A task that represents the completion of the delete operation.
-    /// </returns>
-    ///
+    /// <param name="cancellationToken">Token to control operation cancellation.</param>
+    /// <returns>A task that represents the completion of the delete operation.</returns>
     /// <remarks>
     /// <para>
     /// On success the API returns HTTP 204 (No Content). After deletion, the sending domain represented by this resource instance will no longer be available.
     /// </para>
     /// </remarks>
+    /// <exception cref="OperationCanceledException">The operation was canceled.</exception>
+    /// <exception cref="MailtrapApiException">The API request failed.</exception>
     public Task Delete(CancellationToken cancellationToken = default);
 }

--- a/src/Mailtrap/Core/Http/ResponseHandlers/HttpResponseHandler.cs
+++ b/src/Mailtrap/Core/Http/ResponseHandlers/HttpResponseHandler.cs
@@ -23,11 +23,6 @@ internal abstract class HttpResponseHandler<T> : IHttpResponseHandler<T>
     {
         if (_httpResponseMessage.IsSuccessStatusCode)
         {
-            if (_httpResponseMessage.StatusCode is HttpStatusCode.NoContent)
-            {
-                return default!;
-            }
-
             return await ProcessSuccessResponse(cancellationToken).ConfigureAwait(false);
         }
         else

--- a/src/Mailtrap/Core/Http/ResponseHandlers/HttpResponseHandler.cs
+++ b/src/Mailtrap/Core/Http/ResponseHandlers/HttpResponseHandler.cs
@@ -23,6 +23,11 @@ internal abstract class HttpResponseHandler<T> : IHttpResponseHandler<T>
     {
         if (_httpResponseMessage.IsSuccessStatusCode)
         {
+            if (_httpResponseMessage.StatusCode is HttpStatusCode.NoContent)
+            {
+                return default!;
+            }
+
             return await ProcessSuccessResponse(cancellationToken).ConfigureAwait(false);
         }
         else

--- a/src/Mailtrap/Core/Rest/Commands/DeleteRestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/DeleteRestResourceCommand.cs
@@ -1,7 +1,7 @@
 ﻿namespace Mailtrap.Core.Rest.Commands;
 
 
-internal sealed class DeleteRestResourceCommand<TResponse> : RestResourceCommand<TResponse>
+internal class DeleteRestResourceCommand<TResponse> : RestResourceCommand<TResponse>
 {
     public DeleteRestResourceCommand(
         IHttpClientProvider httpClientProvider,
@@ -15,4 +15,6 @@ internal sealed class DeleteRestResourceCommand<TResponse> : RestResourceCommand
             resourceUri,
             HttpMethod.Delete)
     { }
+
+
 }

--- a/src/Mailtrap/Core/Rest/Commands/DeleteWithStatusCodeResultRestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/DeleteWithStatusCodeResultRestResourceCommand.cs
@@ -1,0 +1,19 @@
+﻿namespace Mailtrap.Core.Rest.Commands;
+
+internal sealed class DeleteWithStatusCodeResultRestResourceCommand : DeleteRestResourceCommand<HttpStatusCode>
+{
+    public DeleteWithStatusCodeResultRestResourceCommand(
+        IHttpClientProvider httpClientProvider,
+        IHttpRequestMessageFactory httpRequestMessageFactory,
+        IHttpResponseHandlerFactory httpResponseHandlerFactory,
+        Uri resourceUri)
+        : base(
+            httpClientProvider,
+            httpRequestMessageFactory,
+            httpResponseHandlerFactory,
+            resourceUri)
+    { }
+
+    protected override IHttpResponseHandler<HttpStatusCode> CreateHttpResponseHandler(HttpResponseMessage httpResponseMessage)
+        => _httpResponseHandlerFactory.CreateStatusCodeHandler(httpResponseMessage);
+}

--- a/src/Mailtrap/Core/Rest/IRestResourceCommandFactory.cs
+++ b/src/Mailtrap/Core/Rest/IRestResourceCommandFactory.cs
@@ -7,6 +7,7 @@ internal interface IRestResourceCommandFactory
     public IRestResourceCommand<string> CreatePlainText(Uri resourceUri, params string[] additionalAcceptContentTypes);
     public IRestResourceCommand<TResponse> CreatePatch<TResponse>(Uri resourceUri);
     public IRestResourceCommand<TResponse> CreateDelete<TResponse>(Uri resourceUri);
+    public IRestResourceCommand<HttpStatusCode> CreateDeleteWithStatusCodeResult(Uri resourceUri);
 
     public IRestResourceCommand<HttpStatusCode> CreatePostWithStatusCodeResult<TRequest>(Uri resourceUri, TRequest request) where TRequest : class;
 

--- a/src/Mailtrap/Core/Rest/RestResourceCommandFactory.cs
+++ b/src/Mailtrap/Core/Rest/RestResourceCommandFactory.cs
@@ -53,6 +53,12 @@ internal sealed class RestResourceCommandFactory : IRestResourceCommandFactory
             _httpResponseHandlerFactory,
             resourceUri);
 
+    public IRestResourceCommand<HttpStatusCode> CreateDeleteWithStatusCodeResult(Uri resourceUri) => new DeleteRestResourceCommand<HttpStatusCode>(
+        _httpClientProvider,
+        _httpRequestMessageFactory,
+        _httpResponseHandlerFactory,
+        resourceUri);
+
     public IRestResourceCommand<HttpStatusCode> CreatePostWithStatusCodeResult<TRequest>(Uri resourceUri, TRequest request)
         where TRequest : class
         => new PostWithStatusCodeResultRestResourceCommand<TRequest>(

--- a/src/Mailtrap/Core/Rest/RestResourceCommandFactory.cs
+++ b/src/Mailtrap/Core/Rest/RestResourceCommandFactory.cs
@@ -53,7 +53,7 @@ internal sealed class RestResourceCommandFactory : IRestResourceCommandFactory
             _httpResponseHandlerFactory,
             resourceUri);
 
-    public IRestResourceCommand<HttpStatusCode> CreateDeleteWithStatusCodeResult(Uri resourceUri) => new DeleteRestResourceCommand<HttpStatusCode>(
+    public IRestResourceCommand<HttpStatusCode> CreateDeleteWithStatusCodeResult(Uri resourceUri) => new DeleteWithStatusCodeResultRestResourceCommand(
         _httpClientProvider,
         _httpRequestMessageFactory,
         _httpResponseHandlerFactory,

--- a/src/Mailtrap/SendingDomains/SendingDomainResource.cs
+++ b/src/Mailtrap/SendingDomains/SendingDomainResource.cs
@@ -24,4 +24,6 @@ internal sealed class SendingDomainResource : RestResource, ISendingDomainResour
             .Execute(cancellationToken)
             .ConfigureAwait(false);
     }
+
+    public async Task Delete(CancellationToken cancellationToken = default) => await Delete(cancellationToken).ConfigureAwait(false);
 }

--- a/src/Mailtrap/SendingDomains/SendingDomainResource.cs
+++ b/src/Mailtrap/SendingDomains/SendingDomainResource.cs
@@ -25,5 +25,9 @@ internal sealed class SendingDomainResource : RestResource, ISendingDomainResour
             .ConfigureAwait(false);
     }
 
-    public async Task Delete(CancellationToken cancellationToken = default) => await Delete(cancellationToken).ConfigureAwait(false);
+    public async Task Delete(CancellationToken cancellationToken = default)
+        => await RestResourceCommandFactory
+            .CreateDeleteWithStatusCodeResult(ResourceUri)
+            .Execute(cancellationToken)
+            .ConfigureAwait(false);
 }

--- a/tests/Mailtrap.IntegrationTests/SendingDomains/SendingDomainIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/SendingDomains/SendingDomainIntegrationTests.cs
@@ -411,17 +411,17 @@ internal sealed class SendingDomainIntegrationTests
     {
         // Arrange
         var random = TestContext.CurrentContext.Random;
+
         var httpMethod = HttpMethod.Delete;
         var accountId = random.NextLong();
-        var sendingDomainId = random.NextLong();
-
+        var domainId = random.NextLong();
         var requestUri = EndpointsTestConstants.ApiDefaultUrl
             .Append(
                 UrlSegmentsTestConstants.ApiRootSegment,
                 UrlSegmentsTestConstants.AccountsSegment)
             .Append(accountId)
             .Append(UrlSegmentsTestConstants.SendingDomainsSegment)
-            .Append(sendingDomainId)
+            .Append(domainId)
             .AbsoluteUri;
 
         var token = random.GetString();
@@ -445,11 +445,10 @@ internal sealed class SendingDomainIntegrationTests
 
         var client = services.GetRequiredService<IMailtrapClient>();
 
-
         // Act
         await client
             .Account(accountId)
-            .SendingDomain(sendingDomainId)
+            .SendingDomain(domainId)
             .Delete()
             .ConfigureAwait(false);
 

--- a/tests/Mailtrap.IntegrationTests/SendingDomains/SendingDomainIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/SendingDomains/SendingDomainIntegrationTests.cs
@@ -405,4 +405,56 @@ internal sealed class SendingDomainIntegrationTests
 
         mockHttp.VerifyNoOutstandingExpectation();
     }
+
+    [Test]
+    public async Task Delete_Success()
+    {
+        // Arrange
+        var random = TestContext.CurrentContext.Random;
+        var httpMethod = HttpMethod.Delete;
+        var accountId = random.NextLong();
+        var sendingDomainId = random.NextLong();
+
+        var requestUri = EndpointsTestConstants.ApiDefaultUrl
+            .Append(
+                UrlSegmentsTestConstants.ApiRootSegment,
+                UrlSegmentsTestConstants.AccountsSegment)
+            .Append(accountId)
+            .Append(UrlSegmentsTestConstants.SendingDomainsSegment)
+            .Append(sendingDomainId)
+            .AbsoluteUri;
+
+        var token = random.GetString();
+        var clientConfig = new MailtrapClientOptions(token);
+
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(httpMethod, requestUri)
+            .WithHeaders("Authorization", $"Bearer {clientConfig.ApiToken}")
+            .WithHeaders("Accept", MimeTypes.Application.Json)
+            .WithHeaders("User-Agent", HeaderValues.UserAgent.ToString())
+            .Respond(HttpStatusCode.NoContent);
+
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection
+            .AddMailtrapClient(clientConfig)
+            .ConfigurePrimaryHttpMessageHandler(() => mockHttp);
+
+        using var services = serviceCollection.BuildServiceProvider();
+
+        var client = services.GetRequiredService<IMailtrapClient>();
+
+
+        // Act
+        await client
+            .Account(accountId)
+            .SendingDomain(sendingDomainId)
+            .Delete()
+            .ConfigureAwait(false);
+
+
+        // Assert
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
 }


### PR DESCRIPTION
## Motivation
I stumbled upon this official railsware mailtrap-dotnet NuGet package and I think its great to offer some help. This so I can use it in production asap. But also because it's nice to so how it is been made.

## Changes

- Added one method to Delete Sending Domain via the API
- Added some tests

## How to test

- [X] Added Delete_Success to Integration tests 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to delete a sending domain via the client SDK. After deletion, the sending domain is no longer available. The example app now demonstrates this flow and logs a confirmation message.
* **Documentation**
  * Added and refined documentation for the sending domain delete operation, including notes on post-deletion behavior. Minor cleanup in related resource docs.
* **Tests**
  * Added integration tests covering successful sending domain deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->